### PR TITLE
feat: LIKE and COURSE Tables Done at Prisma

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,0 @@
-# Environment variables declared in this file are automatically made available to Prisma.
-
-# See the documentation for more detail: https://pris.ly/d/prisma-schema#accessing-environment-variables-from-the-schema
-
-# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
-
-# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
-
-DATABASE_URL="postgresql://username:password@host:5432/dbName?schema=schemaName"

--- a/components/MyComponent.tsx
+++ b/components/MyComponent.tsx
@@ -13,7 +13,10 @@ const MyComponent = () => {
       <h1>Data fetched with GraphQL</h1>
       <div className='flex gap-3'>
         {data.mockModelGetter.map((el: MockModel) => (
-          <div className='bg-gray-200 p-4 flex flex-col items-center rounded-lg shadow-lg'>
+          <div
+            className='bg-gray-200 p-4 flex flex-col items-center rounded-lg shadow-lg'
+            key={el.id}
+          >
             <span>{el.id}</span>
             <span>{el.name}</span>
             <span>{el.description}</span>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,3 +9,26 @@ datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
+
+model LIKE {
+  id String @id @default(cuid())
+
+  //user    USER @relation(fields: [user_id], references: [id])
+  user_id String
+
+  //note    NOTE @relation(fields: [note_id], references: [id])
+  note_id String
+
+  creation_data DateTime @default(now())
+  update_date   DateTime @updatedAt
+}
+
+model COURSE {
+  id       String @id @default(cuid())
+  name     String
+  duration Int
+  link     String
+
+  creation_data DateTime @default(now())
+  update_date   DateTime @updatedAt
+}


### PR DESCRIPTION
Creación del modelo de las entidades 'LIKE' y 'COURSE' en el `schema.prisma` y pequeño hotFix del componente `MyComponent`.