### PR TITLE
feat/Created Course types with basic CRUD definitions

### DIFF
--- a/graphql/server/course/types.ts
+++ b/graphql/server/course/types.ts
@@ -1,0 +1,43 @@
+import { gql } from 'apollo-server-micro';
+
+const CourseTypes = gql`
+  type Course {
+    id: ID
+    name: String
+    duration: Int
+    link: String
+    trainings: [Training]
+    course_states: [CourseState]
+    notes: [Note]
+  }
+
+  input CourseCreateInput {
+    name: String!
+    duration: Int!
+    link: String!
+    trainings: [Training]
+    course_states: [CourseState]
+    notes: [Note]
+  }
+
+  input CourseUpdateInput {
+    name: String
+    duration: Int
+    link: String
+    trainings: [Training]
+    course_states: [CourseState]
+    notes: [Note]
+  }
+
+  type Query {
+    getCourse(id: String): Course
+    getAllCourses: [Course]
+  }
+  type Mutation {
+    createCourse(data: CourseCreateInput): Course
+    updateCourse(data: CourseUpdateInput): Course
+    deleteCourse(id: String): Course
+  }
+`;
+
+export { CourseTypes };

--- a/graphql/server/types.ts
+++ b/graphql/server/types.ts
@@ -1,6 +1,6 @@
 import { DocumentNode } from 'graphql';
 import { gql } from 'apollo-server-micro';
-import { model1Types } from '@graphql/server/model1/types';
+import { CourseTypes } from '@graphql/server/course/types';
 
 const CommonTypes = gql`
   scalar Date
@@ -8,10 +8,7 @@ const CommonTypes = gql`
 
 const GlobalTypes: DocumentNode[] = [
   CommonTypes,
-  model1Types,
-  model1Types,
-  model1Types,
-  model1Types,
+  CourseTypes,
 ];
 
 export { GlobalTypes };

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -97,7 +97,7 @@ model COURSE {
   duration Int
   link     String
 
-  creation_data DateTime @default(now())
+  creation_date DateTime @default(now())
   update_date   DateTime @updatedAt
 
   trainings     TRAINING[]


### PR DESCRIPTION
Created the Course types with 5 basic operations: get, get all, create, update by id, and delete by id.
I also had to change the prisma model since there was a typo in the course model.